### PR TITLE
Print braille feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,8 @@ from dictionary_en import *
 
 app = Flask(__name__)
 api = Api(app)
-talisman = Talisman(app)
+
+talisman = Talisman(app, force_https=app.env != 'development', content_security_policy=False)
 
 app.config['JSON_AS_ASCII'] = False
 app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres://arjhncjjjotxbc:3b583653ee3754dba776fc3a488267c8269b6b8186eb5981056aa970cc707c8f@ec2-23-23-36-227.compute-1.amazonaws.com:5432/d6fks0t2bevn18'

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,7 +11,7 @@
 
 * { -webkit-box-sizing:border-box; -moz-box-sizing:border-box; -ms-box-sizing:border-box; -o-box-sizing:border-box; box-sizing:border-box; }
 
-html { width: 100%; height:100%; overflow:hidden; }
+html { width: 100%; height:100%; margin: 0 }
 
 body { 
 	width: 100%;
@@ -22,6 +22,7 @@ body {
 	font-size: 18px;
 	text-align:center;
 	letter-spacing:1.2px;
+	margin: 0;
 	background: -moz-radial-gradient(0% 100%, ellipse cover, rgba(104,128,138,.4) 10%,rgba(138,114,76,0) 40%),-moz-linear-gradient(top,  rgba(57,173,219,.25) 0%, rgba(42,60,87,.4) 100%), -moz-linear-gradient(-45deg,  #670d10 0%, #092756 100%);
 	background: -webkit-radial-gradient(0% 100%, ellipse cover, rgba(104,128,138,.4) 10%,rgba(138,114,76,0) 40%), -webkit-linear-gradient(top,  rgba(57,173,219,.25) 0%,rgba(42,60,87,.4) 100%), -webkit-linear-gradient(-45deg,  #670d10 0%,#092756 100%);
 	background: -o-radial-gradient(0% 100%, ellipse cover, rgba(104,128,138,.4) 10%,rgba(138,114,76,0) 40%), -o-linear-gradient(top,  rgba(57,173,219,.25) 0%,rgba(42,60,87,.4) 100%), -o-linear-gradient(-45deg,  #670d10 0%,#092756 100%);
@@ -30,21 +31,14 @@ body {
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#3E1D6D', endColorstr='#092756',GradientType=1 );
 
 }
-.login { 
-	/* position: absolute;
-	top: 40%;
-	left: 50%; */
+.braille {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	/* justify-content: center; */
 	padding-top: 20vh;
-	/* margin: -150px 0 0 -150px; */
-	width:100vw;
-	height:100vh;
 }
 
-.login h1 { color: #fff; text-shadow: 0 0 10px rgba(0,0,0,0.3); letter-spacing:1px; text-align:center; }
+.braille h1 { color: #fff; text-shadow: 0 0 10px rgba(0,0,0,0.3); letter-spacing:1px; text-align:center; }
 
 input { 
 	width: 700px; 
@@ -88,9 +82,7 @@ input:focus { box-shadow: inset 0 -5px 45px rgba(100,100,100,0.4), 0 1px 1px rgb
 
 footer {
 	width: 100%;
-	position: fixed;
 	text-align: center;
-	bottom: 0;
 	padding: 2rem;
 	color: white;
   }
@@ -126,4 +118,61 @@ footer {
     font-size:100%;
     vertical-align:baseline;
     background:transparent;
+	}
+
+	.braille-output {
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid rgba(0, 0, 0, 0.3);
+		border-radius: 4px;
+		box-shadow: inset 0 -5px 45px rgba(100, 100, 100, 0.2), 0 1px 1px rgba(255, 255, 255, 0.2);
+		width: 700px;
+		line-height: 30px;
+		margin-top: 10px;
+	}
+
+	.braille-output .printer {
+		float: right;
+		margin: 20px 10px;
+	}
+
+	.braille-output p {
+		display: inline-block;
+		font-size: 22px;
+	}
+
+	@media print {
+		body {
+			background: #fff
+		}
+		.braille {
+			padding-top: 10px;
+		}
+		.braille h1 {
+			display: none;
+		}
+		.braille form {
+			display: none;
+		}
+		.braille-output .printer {
+			display: none;
+		}
+		.braille-output {
+			margin: 0 auto;
+			padding: 15px;
+			width: 100%;
+			color: #000;
+			text-shadow: none;
+			box-shadow: none;
+			border: none;
+			background: none;
+		}
+		.braille-output p {
+			line-height: 1.5em;
+			font-size: 2em;
+			background: none;
+			margin: 0;
+		}
+		footer {
+			display: none;
+		}
 	}

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,24 +37,22 @@
 </head>
 
 <body>
- <div class="login">
+ <div class="braille">
 	<h1>Braille Translator</h1>
 
      <!-- Main Input For Receiving Query to our ML -->
     <form action="{{ url_for('translation')}}"method="post">
-    	<input type="text" name="main_text" placeholder="Enter text here" required="required" value="{{translator_text}}"/>
+    	<input type="text" name="main_text" placeholder="Enter text here" required="required" value="{{translator_text}}" autofocus/>
 
       <button type="submit" class="btn btn-primary btn-block btn-large">Translate</button>
     </form>
 
-   <br>
-   <br>
-   <!-- {% if prediction_text %}
-   <h2>{{ prediction_text }}</h2>
-    {% endif %} -->
-    <h2 style="{{'display: none;' if not prediction_text }}">{{prediction_text}}</h2>
-
-
+   {% if prediction_text %}
+    <div class="braille-output">
+      <p>{{prediction_text}}</p>
+      <button class="btn printer" title="Print this braille" onclick="window.print()">🖨️</button>
+    </div>
+    {% endif %}
  </div>
 
  <footer>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Braille Translator</title>
-  <link href='https://fonts.googleapis.com/css?family=Pacifico' rel='stylesheet' type='text/css'>
-<link href='https://fonts.googleapis.com/css?family=Arimo' rel='stylesheet' type='text/css'>
-<link href='https://fonts.googleapis.com/css?family=Hind:300' rel='stylesheet' type='text/css'>
-<link href='https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-BFE8TQ1L1X"></script>


### PR DESCRIPTION
A great feature is to users able to print the braille text after conversion. There are special printers, I don't know how they work and how integrate with them. But for now, I added a print button and made a simple black page with only the braille characters using CSS `@media print`

Will be cool if we know how to integrate and make de font adjustments for correctly print the braille. 

This also work if the user hit `CTRL + P` on the browser!

The button:
![Captura de Tela 2020-12-25 às 10 08 16](https://user-images.githubusercontent.com/5942637/103135811-d7d60480-4699-11eb-8cf1-bf7dfe91f1c5.png)

Printing example:
![Captura de Tela 2020-12-25 às 10 08 25](https://user-images.githubusercontent.com/5942637/103135826-ed4b2e80-4699-11eb-8a51-d2767722007e.png)

----

Also, I guess there is a need to improve the visualization for big text conversions, maybe using `<textarea>` / scroll?

----
PS.: For the `window.print()` to work there are a need to filter correctly the content-security-policy, I guess there isn't need for this now, and I removed some google fonts, probably from the initial boilerplate. 